### PR TITLE
Feat: axios interceptor 임시 설정 및 회원가입 조건에 비밀번호 8자 이상 및 학교 이메일로 제한 설정

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -7,4 +7,17 @@ const api = axios.create({
   },
 });
 
+api.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
 export default api;

--- a/src/api/signup/login.js
+++ b/src/api/signup/login.js
@@ -5,7 +5,7 @@ export const login = async (userData) => {
     const response = await api.post('/api/auth/login', userData);
     console.log(response);
     if (response.data.status === 'OK') {
-      const { accessToken, refreshToken } = response.data;
+      const { accessToken, refreshToken } = response.data.data;
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
       return true;

--- a/src/pages/Signup/Signup.jsx
+++ b/src/pages/Signup/Signup.jsx
@@ -108,7 +108,7 @@ export default function Signup() {
       console.error('회원가입 오류:', error);
       switch (status) {
         case 400:
-          alert(errorMessage || '요청이 잘못되었습니다.');
+          alert(errorMessage || '비밀번호를 8자 이상 입력하세요');
           break;
         case 409:
           alert(errorMessage || '요청이 잘못되었습니다.');
@@ -207,7 +207,8 @@ export default function Signup() {
             </InputLabel>
             <AuthButton
               type="button"
-              $disabled={!userFormData.email.includes('@')}
+              $isDisabled={!userFormData.email.includes('@hufs.ac.kr')}
+              disabled={!userFormData.email.includes('@hufs.ac.kr')}
               onClick={handleSendCode}
             >
               인증번호 받기
@@ -317,12 +318,12 @@ const AuthButton = styled.button`
   align-items: center;
 
   border-radius: 3px;
-  border: 1px solid ${({ $disabled }) => ($disabled ? '#ddd' : '#3092FA')};
+  border: 1px solid ${({ $isDisabled }) => ($isDisabled ? '#ddd' : '#3092FA')};
 
-  color: ${({ $disabled }) => ($disabled ? '#ddd' : '#3092FA')};
+  color: ${({ $isDisabled }) => ($isDisabled ? '#ddd' : '#3092FA')};
   ${({ theme }) => theme.fontStyles.Body7};
   transition: all 0.3s ease;
-  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  cursor: ${({ $isDisabled }) => ($isDisabled ? 'not-allowed' : 'pointer')};
 `;
 
 const AuthConfirm = styled(AuthButton)`


### PR DESCRIPTION
## PR 제목

### 이슈 번호 📎

- #34 

### 변경사항 🛠

- axios interceptor 임시 설정(현재 요청할 때 자동으로 토큰 추가)
- 비밀번호 8자 이상으로 제한
- 이메일 인증 코드 보낼때 학교 이메일만 허용

### 특이사항 📌

- axios interceptor에서 accesstoken 만료 시, refresh 토큰을 통해 새로운 토큰 재발급 로직 구현 예정입니다.
