### PR TITLE
feat(chat) : 채팅화면 API 연동 

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,9 @@
   <body>
     <div id="root"></div>
     <div id="modal"></div>
+    <script>
+      window.global = window;
+    </script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.1.1",
     "axios": "^1.9.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.5.0",
     "react-router-dom": "^7.6.0",
+    "sockjs-client": "^1.6.1",
+    "stompjs": "^2.3.3",
     "styled-components": "^6.1.17"
   },
   "devDependencies": {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Chat from '@pages/Chat/Chat';
 import Signup from '@pages/Signup/Signup';
 import ProductDetail from '@pages/ProductDetail/ProductDetail';
 import EditPost from '@pages/Post/EditPost';
+import RequireAuth from '@components/RequireAuth';
 
 function App() {
   return (
@@ -21,7 +22,14 @@ function App() {
           <Route path="detail/:post_id" element={<ProductDetail />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/mypage" element={<MyPage />} />
-          <Route path="chat" element={<Chat />} />
+          <Route
+            path="chat"
+            element={
+              <RequireAuth>
+                <Chat />
+              </RequireAuth>
+            }
+          />
           <Route path="/signup" element={<Signup />} />
           <Route path="/edit/:postId" element={<EditPost />} />
         </Route>

--- a/src/api/signup/login.js
+++ b/src/api/signup/login.js
@@ -5,9 +5,11 @@ export const login = async (userData) => {
     const response = await api.post('/api/auth/login', userData);
     console.log(response);
     if (response.data.status === 'OK') {
-      const { accessToken, refreshToken } = response.data.data;
+      const { accessToken, refreshToken, userId, email } = response.data.data;
       localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('refreshToken', refreshToken);
+      localStorage.setItem('userId', userId);
+      localStorage.setItem('userEmail', email);
       return true;
     } else {
       alert('로그인 실패!');

--- a/src/components/Chat/ChatRoomList.jsx
+++ b/src/components/Chat/ChatRoomList.jsx
@@ -1,50 +1,52 @@
+import api from '@api/api';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import QuitButtonIcon from '@assets/chat/quit-button.svg?react';
+import GroupImage from '@assets/chat/group-image.svg';
 import { Container } from '@components/shared/UIStyles';
-import { Avatar } from './shared/Avatar';
+import { Avatar } from '@components/Chat/shared/Avatar';
 
-// 채팅방 목록 아이템
-export function ChatRoomItem({ room, active, onClick }) {
-  return (
-    <ChatRoomItemBox $active={active} onClick={onClick}>
-      <AvatarWrapper>
-        <Avatar src={room.avatar} alt={room.title} />
-        {room.unreadCount > 0 && !room.isRead && <UnreadDot />}
-      </AvatarWrapper>
-      <RoomInfo>
-        <RoomTitleRow>
-          <RoomTitle>{room.title}</RoomTitle>
-          <RoomTime>{room.time}</RoomTime>
-        </RoomTitleRow>
-        <RoomLastMsg>{room.lastMessage}</RoomLastMsg>
-      </RoomInfo>
-    </ChatRoomItemBox>
-  );
-}
+export function ChatRoomList({ activeRoomId, onRoomClick }) {
+  const [rooms, setRooms] = useState([]);
+  const [error, setError] = useState(null);
 
-ChatRoomItem.propTypes = {
-  room: PropTypes.shape({
-    avatar: PropTypes.string,
-    title: PropTypes.string,
-    unreadCount: PropTypes.number,
-    isRead: PropTypes.bool,
-    time: PropTypes.string,
-    lastMessage: PropTypes.string,
-  }).isRequired,
-  active: PropTypes.bool,
-  onClick: PropTypes.func,
-};
+  // 채팅방 목록 조회
+  useEffect(() => {
+    const fetchRooms = async () => {
+      try {
+        const res = await api.get('/api/auth/users/chats');
+        console.log('채팅방 목록:', res.data.data);
+        if (res.data.status === 'OK' && Array.isArray(res.data.data)) {
+          setRooms(res.data.data);
+          setError(null);
+        } else {
+          setRooms([]);
+          setError('채팅방 목록을 불러오지 못했습니다.');
+        }
+      } catch (e) {
+        if (e.response?.status === 404) {
+          setError('해당 유저가 존재하지 않습니다.');
+        } else {
+          setError('채팅방 목록을 불러오는 중 오류가 발생했습니다.');
+        }
+        setRooms([]);
+      }
+    };
+    fetchRooms();
+  }, []);
 
-export function ChatRoomList({ rooms, activeRoomId, onRoomClick }) {
+  if (error) {
+    return <ErrorMessage>{error}</ErrorMessage>;
+  }
+
   return (
     <ChatRoomListBox>
       {rooms.map((room) => (
         <ChatRoomItem
-          key={room.id}
+          key={room.roomId}
           room={room}
-          active={room.id === activeRoomId}
-          onClick={() => onRoomClick(room.id)}
+          active={room.roomId === activeRoomId}
+          onClick={() => onRoomClick(room.roomId)}
         />
       ))}
     </ChatRoomListBox>
@@ -52,37 +54,68 @@ export function ChatRoomList({ rooms, activeRoomId, onRoomClick }) {
 }
 
 ChatRoomList.propTypes = {
-  rooms: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      avatar: PropTypes.string,
-      title: PropTypes.string,
-      unreadCount: PropTypes.number,
-      isRead: PropTypes.bool,
-      time: PropTypes.string,
-      lastMessage: PropTypes.string,
-    })
-  ).isRequired,
+  rooms: PropTypes.arrayOf(PropTypes.object).isRequired,
   activeRoomId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onRoomClick: PropTypes.func,
+  onRoomClick: PropTypes.func.isRequired,
 };
 
-export function QuitButton({ onQuit }) {
-  const handleClick = () => {
-    if (window.confirm('채팅방을 나가고 공동구매 참여를 취소하시겠습니까?')) {
-      if (onQuit) onQuit();
+export default ChatRoomList;
+
+function ChatRoomItem({ room, active, onClick }) {
+  const getTime = (timeStr) => {
+    if (!timeStr || typeof timeStr !== 'string') return '';
+    // ISO 8601 형태에서 HH:MM만 추출
+    if (timeStr.length >= 16 && timeStr[10] === 'T') {
+      return timeStr.slice(11, 16);
     }
+    // 혹시 "14:28:55" 형태면 앞 5글자만
+    if (timeStr.length >= 5) {
+      return timeStr.slice(0, 5);
+    }
+    return '';
   };
+
+  // unreadMessageCount가 0이면 토글 비활성, 1 이상이면 활성
   return (
-    <QuitButtonWrapper onClick={handleClick}>
-      <QuitButtonIcon width={32} height={32} />
-    </QuitButtonWrapper>
+    <ChatRoomItemBox $active={active} onClick={onClick}>
+      <AvatarWrapper>
+        <Avatar src={GroupImage} alt={room.roomName} />
+        {room.unreadMessageCount > 0 && <UnreadDot />}
+      </AvatarWrapper>
+      <RoomInfo>
+        <RoomTitleRow>
+          <RoomTitle>{room.roomName}</RoomTitle>
+          <RoomTime>{getTime(room.lastMessage?.time)}</RoomTime>
+        </RoomTitleRow>
+        <RoomLastMsg>{room.lastMessage?.content || ''}</RoomLastMsg>
+      </RoomInfo>
+    </ChatRoomItemBox>
   );
 }
 
-QuitButton.propTypes = {
-  onQuit: PropTypes.func,
+ChatRoomItem.propTypes = {
+  room: PropTypes.shape({
+    roomId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    roomName: PropTypes.string.isRequired,
+    unreadMessageCount: PropTypes.number,
+    lastMessage: PropTypes.shape({
+      content: PropTypes.string,
+      time: PropTypes.string,
+    }),
+  }).isRequired,
+  active: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
 };
+
+const ChatRoomListBox = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+`;
 
 const ChatRoomItemBox = styled(Container)`
   flex-direction: row;
@@ -93,7 +126,6 @@ const ChatRoomItemBox = styled(Container)`
 `;
 
 const AvatarWrapper = styled.div`
-  position: relative;
   display: inline-block;
 `;
 
@@ -145,24 +177,16 @@ const RoomLastMsg = styled.div`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  align-self: flex-start;
+  text-align: left;
 `;
 
-const ChatRoomListBox = styled.div`
-  flex: 1;
-  overflow-y: auto;
-  &::-webkit-scrollbar {
-    display: none;
-  }
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-`;
-
-const QuitButtonWrapper = styled.button`
-  width: 32px;
-  height: 32px;
-
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
+const ErrorMessage = styled(Container)`
+  ${({ theme }) => theme.fontStyles.Body7};
+  font-weight: 500;
+  color: #6b7280;
+  width: 100%;
+  height: 100%;
+  justify-content: center;
+  text-align: center;
 `;

--- a/src/components/Chat/MessageList.jsx
+++ b/src/components/Chat/MessageList.jsx
@@ -1,16 +1,36 @@
-import React from 'react';
+import Stomp from 'stompjs';
+import api from '@api/api';
+import React, { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import SendIcon from '@assets/chat/send-icon.svg?react';
-import { Avatar } from './shared/Avatar';
+import QuitButtonIcon from '@assets/chat/quit-button.svg?react';
+import UserImage from '@assets/icons/user-image.svg';
 import { Container } from '@components/shared/UIStyles';
+import { Avatar } from '@components/Chat/shared/Avatar';
+import { ButtonStyle } from '@components/shared/ButtonStyle';
 
-export function MessageItem({ msg }) {
+// 날짜 구분선
+function DateSeparator({ date }) {
+  return <DateSeparatorLine>{date}</DateSeparatorLine>;
+}
+
+DateSeparator.propTypes = {
+  date: PropTypes.string.isRequired,
+};
+
+// 메시지 아이템
+function MessageItem({ msg }) {
   if (msg.mine) {
     return (
       <MyMessage>
         <MsgMetaCol $align="right">
-          {msg.unreadCount > 0 && <UnreadText>{msg.unreadCount}</UnreadText>}
+          {msg.unreadCount === 0 ? (
+            <CheckMark>✔</CheckMark>
+          ) : (
+            <UnreadText>{msg.unreadCount}</UnreadText>
+          )}
           <MsgTime>{msg.time}</MsgTime>
         </MsgMetaCol>
         <MyMsgBubble>{msg.content}</MyMsgBubble>
@@ -19,13 +39,17 @@ export function MessageItem({ msg }) {
   }
   return (
     <OtherMessageRow>
-      <Avatar src={msg.avatar} alt={msg.sender} size="40px" />
+      <Avatar src={UserImage} alt={msg.senderNickname} />
       <OtherMsgContent>
-        <SenderName>{msg.sender}</SenderName>
+        <SenderName>{msg.senderNickname}</SenderName>
         <MsgBubbleRow>
           <OtherMsgBubble>{msg.content}</OtherMsgBubble>
           <MsgMetaCol $align="left">
-            {msg.unreadCount > 0 && <UnreadText>{msg.unreadCount}</UnreadText>}
+            {msg.unreadCount === 0 ? (
+              <CheckMark>✔</CheckMark>
+            ) : (
+              <UnreadText>{msg.unreadCount}</UnreadText>
+            )}
             <MsgTime>{msg.time}</MsgTime>
           </MsgMetaCol>
         </MsgBubbleRow>
@@ -40,84 +64,325 @@ MessageItem.propTypes = {
     unreadCount: PropTypes.number,
     time: PropTypes.string,
     content: PropTypes.string,
-    avatar: PropTypes.string,
-    sender: PropTypes.string,
-  }).isRequired,
+    senderNickname: PropTypes.string,
+  }),
 };
 
-export function DateSeparator({ date }) {
-  return <DateSeparatorLine>{date}</DateSeparatorLine>;
-}
+export function MessageList({ room, onQuit }) {
+  const [messages, setMessages] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+  const listRef = useRef();
+  const navigate = useNavigate();
 
-DateSeparator.propTypes = {
-  date: PropTypes.string.isRequired,
-};
+  const stompRef = useRef(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [connectError, setConnectError] = useState(null);
 
-export function MessageList({ messages }) {
+  const WS_URL = import.meta.env.VITE_WS_URL || 'ws://localhost:8080/connect';
+  const token = localStorage.getItem('accessToken');
+  const myEmail = localStorage.getItem('userEmail');
+
+  // 상품 정보
+  const product = room.product || {};
+  const productImage = Array.isArray(product.imageUrl)
+    ? product.imageUrl[0]
+    : product.imageUrl || '';
+  const productTitle = product.title || '';
+  const productPrice = Number(product.price) || 0;
+  const maxParticipants = Number(product.maxParticipants) || 1;
+
+  const unitPrice = maxParticipants > 0 ? Math.round(productPrice / maxParticipants) : productPrice;
+
+  // 날짜/시간 분리 함수
+  function parseDateTime(isoString) {
+    if (!isoString) return { date: '', time: '' };
+    const dateObj = new Date(isoString);
+    const yyyy = dateObj.getFullYear();
+    const mm = String(dateObj.getMonth() + 1).padStart(2, '0');
+    const dd = String(dateObj.getDate()).padStart(2, '0');
+    const hh = String(dateObj.getHours()).padStart(2, '0');
+    const min = String(dateObj.getMinutes()).padStart(2, '0');
+    return {
+      date: `${yyyy}-${mm}-${dd}`,
+      time: `${hh}:${min}`,
+    };
+  }
+
+  // 1. 최초 진입 시 REST로 메시지 이력 한 번 불러오기
+  useEffect(() => {
+    if (!room?.roomId) return;
+    const fetchMessages = async () => {
+      try {
+        const res = await api.get(`/api/chats/history/${room.roomId}`);
+        if (res.data.status === 'OK') {
+          const msgs = (res.data.data || []).map((msg) => {
+            const { date, time } = parseDateTime(msg.createdTime);
+            return {
+              id: msg.id || `${msg.roomId}-${msg.createdTime}`,
+              content: msg.message,
+              senderNickname: msg.senderNickname,
+              unreadCount: typeof msg.readMessageCount === 'number' ? msg.readMessageCount : 0,
+              time,
+              date,
+              mine: msg.senderEmail === myEmail,
+            };
+          });
+          setMessages(msgs);
+        }
+      } catch {
+        setMessages([]);
+      }
+    };
+    fetchMessages();
+  }, [room?.roomId, myEmail]);
+
+  // 2. WebSocket 연결 및 구독
+  useEffect(() => {
+    if (!room?.roomId || !token) return;
+    setIsConnected(false);
+    setConnectError(null);
+
+    // Bearer prefix 제거
+    const cleanToken = token.startsWith('Bearer ') ? token.substring(7) : token;
+    const socketUrl = `${WS_URL}?token=${encodeURIComponent(cleanToken)}`;
+
+    const socket = new WebSocket(socketUrl);
+    const stompClient = Stomp.over(socket);
+    stompRef.current = stompClient;
+
+    stompClient.connect(
+      {},
+      () => {
+        setIsConnected(true);
+        console.log('WebSocket 연결 성공');
+        setConnectError(null);
+        stompClient.subscribe(`/topic/${room.roomId}`, (message) => {
+          const data = JSON.parse(message.body);
+          setMessages((prev) => [...prev, data]);
+        });
+      },
+      (error) => {
+        setIsConnected(false);
+        setConnectError('연결 실패. 로그인 상태를 확인하거나 다시 시도하세요.');
+        console.error('WebSocket 연결 실패:', error);
+      }
+    );
+    stompClient.onStompError = () => {
+      setIsConnected(false);
+      setConnectError('STOMP 오류 발생');
+      console.error('STOMP 에러');
+    };
+    stompClient.onWebSocketError = () => {
+      setIsConnected(false);
+      setConnectError('WebSocket 에러 발생');
+      console.error('WebSocket 에러');
+    };
+
+    return () => {
+      if (stompRef.current && stompRef.current.connected) {
+        stompRef.current.disconnect(() => {
+          setIsConnected(false);
+        });
+      }
+    };
+  }, [room?.roomId, token, WS_URL]);
+
+  // 스크롤 하단 이동
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollTop = listRef.current.scrollHeight;
+    }
+  }, [messages]);
+
+  // 메시지 전송
+  const handleSend = () => {
+    if (!inputValue.trim() || !room?.roomId) return;
+    if (stompRef.current && isConnected) {
+      stompRef.current.send(
+        `/publish/${room.roomId}`,
+        {},
+        JSON.stringify({
+          roomId: Number(room.roomId),
+          message: inputValue,
+          //senderEmail: myEmail
+        })
+      );
+      setInputValue('');
+    } else {
+      alert(connectError || '채팅 서버에 연결 중입니다. 잠시 후 다시 시도해주세요.');
+    }
+  };
+
+  // 게시글 상세페이지 이동
+  const handleView = () => {
+    const productId = room.product?.productId;
+    if (productId) {
+      navigate(`/detail/${productId}`);
+    }
+  };
+
   let lastDate = null;
+
   return (
-    <MessageListBox>
-      {messages.map((msg) => {
-        const showDate = msg.date !== lastDate;
-        lastDate = msg.date;
-        return (
-          <React.Fragment key={msg.id}>
-            {showDate && <DateSeparator date={msg.date} />}
-            <MessageItem msg={msg} />
-          </React.Fragment>
-        );
-      })}
-    </MessageListBox>
+    <>
+      <MainHeader>
+        <MainRow>
+          <MainHeaderLeft>
+            <MainTitle>
+              {room.product?.title
+                ? `${room.product.title} 단톡방`
+                : room.title
+                  ? `${room.title} 단톡방`
+                  : '단톡방'}
+            </MainTitle>
+          </MainHeaderLeft>
+          {!room.isHost && (
+            <QuitButtonWrapper onClick={onQuit}>
+              <QuitButtonIcon width={32} height={32} />
+            </QuitButtonWrapper>
+          )}
+        </MainRow>
+        <MainRow>
+          <ProductInfo>
+            <ProductAvatar src={productImage} alt="" />
+            <ProductDetails>
+              <ProductName>{productTitle}</ProductName>
+              <ProductPrice>{unitPrice.toLocaleString()}원 ~</ProductPrice>
+            </ProductDetails>
+            <ViewButton onClick={handleView}>View</ViewButton>
+          </ProductInfo>
+        </MainRow>
+      </MainHeader>
+      <MessageListBox ref={listRef}>
+        {messages.map((msg, idx) => {
+          const showDate = msg.date !== lastDate;
+          lastDate = msg.date;
+          return (
+            <React.Fragment key={msg.id || idx}>
+              {showDate && <DateSeparator date={msg.date} />}
+              <MessageItem msg={msg} />
+            </React.Fragment>
+          );
+        })}
+      </MessageListBox>
+      <InputArea>
+        <InputBox
+          placeholder="메시지를 입력하세요"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleSend();
+          }}
+        />
+        <SendButton onClick={handleSend}>
+          <SendIcon />
+        </SendButton>
+      </InputArea>
+    </>
   );
 }
 
 MessageList.propTypes = {
-  messages: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-      date: PropTypes.string,
-      mine: PropTypes.bool,
-      unreadCount: PropTypes.number,
-      time: PropTypes.string,
-      content: PropTypes.string,
-      avatar: PropTypes.string,
-      sender: PropTypes.string,
-    })
-  ).isRequired,
+  room: PropTypes.object.isRequired,
+  onQuit: PropTypes.func.isRequired,
 };
 
-export function ChatInput({ value, onChange, onSend }) {
-  return (
-    <InputArea>
-      <InputBox
-        placeholder="메세지를 입력하세요"
-        value={value}
-        onChange={onChange}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') onSend();
-        }}
-      />
-      <SendButton onClick={onSend}>
-        <SendIcon />
-      </SendButton>
-    </InputArea>
-  );
-}
+export default MessageList;
 
-ChatInput.propTypes = {
-  value: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  onSend: PropTypes.func.isRequired,
-};
+const MainHeader = styled(Container)`
+  width: 100%;
+  height: 155px;
+  padding: 16px;
+  border-bottom: 1px solid #e5e7eb;
+
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const MainRow = styled(Container)`
+  width: 100%;
+
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const MainHeaderLeft = styled(Container)`
+  flex-direction: row;
+  margin-left: 12px;
+`;
+
+const MainTitle = styled.div`
+  ${({ theme }) => theme.fontStyles.Body6};
+  font-weight: 600;
+  color: #333;
+`;
+
+const QuitButtonWrapper = styled.button`
+  width: 32px;
+  height: 32px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+`;
+
+const ProductInfo = styled(Container)`
+  width: 100%;
+  height: 72px;
+  padding: 12px;
+
+  flex-direction: row;
+  background: #f9fbff;
+  border-radius: 4px;
+`;
+
+const ProductAvatar = styled.img`
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  margin-right: 12px;
+`;
+
+const ProductDetails = styled(Container)`
+  flex: 1;
+  align-items: flex-start;
+  gap: 5px;
+`;
+
+const ProductName = styled.p`
+  ${({ theme }) => theme.fontStyles.Body7};
+  font-weight: 600;
+  color: #555;
+`;
+
+const ProductPrice = styled.p`
+  ${({ theme }) => theme.fontStyles.Body8};
+  font-weight: 500;
+  color: #666;
+`;
+
+const ViewButton = styled(ButtonStyle)`
+  width: 62px;
+  height: 36px;
+  ${({ theme }) => theme.fontStyles.Body7};
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+`;
 
 const MessageListBox = styled(Container)`
   width: 100%;
   padding: 16px;
   background: #f9fafb;
   overflow-y: auto;
-
   align-items: stretch;
   gap: 10px;
+  flex: 1;
 `;
 
 const OtherMessageRow = styled.div`
@@ -202,7 +467,6 @@ const InputArea = styled(Container)`
   background: #fff;
   box-sizing: border-box;
   border-radius: 0 0 4px 0;
-
   flex-direction: row;
   gap: 12px;
 `;
@@ -236,4 +500,11 @@ const DateSeparatorLine = styled.div`
   text-align: center;
   padding: 20px 0 8px 0;
   color: #999;
+`;
+
+const CheckMark = styled.span`
+  color: #3092fa;
+  ${({ theme }) => theme.fontStyles.Body7};
+  margin-right: 2px;
+  vertical-align: middle;
 `;

--- a/src/components/ProductDetail/ProductInfo.jsx
+++ b/src/components/ProductDetail/ProductInfo.jsx
@@ -1,3 +1,4 @@
+import api from '@api/api';
 import styled from 'styled-components';
 import { Container } from '@components/shared/UIStyles';
 import { ButtonStyle } from '@components/shared/ButtonStyle';
@@ -27,25 +28,78 @@ function formatDate(dateStr) {
 const ProductInfoAndButtons = ({ detail }) => {
   const navigate = useNavigate();
 
+  const postId = detail.productId || detail.id;
+
   const originPrice = detail.price;
-  const unitPrice = detail.maxParticipants
-    ? Math.round(detail.price / detail.maxParticipants).toLocaleString()
-    : detail.price.toLocaleString();
+  const maxParticipants = detail.maxParticipants || 1;
+  const currentParticipants = detail.currentParticipants || 0;
+  const unitPrice = Math.round(originPrice / maxParticipants).toLocaleString();
 
   const created = formatDate(detail.createdAt || detail.updatedAt);
   const deadline = formatDate(detail.deadline);
 
   const isLoggedIn = !!localStorage.getItem('accessToken');
-  const handleParticipate = () => {
+  const isClosed = currentParticipants >= maxParticipants;
+
+  // 공동구매 참여 버튼 클릭 시
+  const handleParticipate = async () => {
     if (!isLoggedIn) {
-      alert('로그인 후 이용해주세요.');
-      navigate('/Login');
-    } else {
+      alert('로그인이 필요합니다.');
+      navigate('/login');
+      return;
+    }
+    if (!detail.productId) {
+      alert('잘못된 상품 정보입니다.');
+      return;
+    }
+
+    try {
+      // 1. 공동구매 상태 확인
+      const statusRes = await api.get(`/api/group-buyings/${postId}/status`);
+      const isJoined = statusRes.data?.data?.isJoined;
+
+      if (isJoined) {
+        if (window.confirm('이미 참여한 공동구매입니다! 채팅화면으로 이동하시겠습니까?')) {
+          navigate('/chat');
+        }
+        return;
+      }
+
       if (window.confirm('공동구매에 참여하시겠습니까?')) {
-        navigate('/chat');
+        const joinRes = await api.post('/api/group-buyings/join', { postId });
+        console.log('공동구매 참여 성공, joinRes:', joinRes.data);
+        const chatRes = await api.post(`/api/posts/${postId}/chat/join`);
+        console.log('채팅방 입장 성공, chatRes:', chatRes.data);
+        if (chatRes.data.status === 'OK' && chatRes.data.data?.roomId) {
+          const roomId = chatRes.data.data.roomId;
+          navigate('/chat', { state: { roomId } });
+        } else {
+          alert('채팅방 입장에 실패했습니다.');
+        }
+      }
+    } catch (e) {
+      console.error('공동구매 참여 실패:', e.response?.data || e);
+      const msg = e.response?.data?.message || '';
+      if (e.response?.status === 409 && msg.includes('already joined')) {
+        if (window.confirm('이미 참여한 공동구매입니다! 채팅화면으로 이동하시겠습니까?')) {
+          navigate('/chat');
+        }
+      } else if (msg.includes('closed')) {
+        alert('마감된 공동구매입니다.');
+      } else if (msg.includes('forbidden')) {
+        alert('작성자는 본인 게시글에 참여할 수 없습니다.');
+      } else if (e.response?.status === 401) {
+        alert('로그인 정보가 유효하지 않습니다. 다시 로그인 해주세요.');
+        navigate('/login');
+      } else if (e.response?.status === 404) {
+        alert('존재하지 않는 게시글입니다.');
+      } else {
+        alert('채팅방 참여에 실패했습니다.');
       }
     }
   };
+
+  // 1:1 문의하기 버튼 클릭 시
   const handleInquiry = () => {
     alert('아직 구현 못했습니다! :(');
   };
@@ -72,7 +126,9 @@ const ProductInfoAndButtons = ({ detail }) => {
         <InfoSubTitle>{detail.place}</InfoSubTitle>
       </ProductContainer>
       <ButtonRow>
-        <ParticipateButton onClick={handleParticipate}>공동구매 참여하기</ParticipateButton>
+        <ParticipateButton onClick={handleParticipate} $closed={isClosed} disabled={isClosed}>
+          {isClosed ? '모집 마감' : '공동구매 참여하기'}
+        </ParticipateButton>
         <InquiryButton onClick={handleInquiry}>1 : 1 문의하기</InquiryButton>
       </ButtonRow>
     </ProductInfo>
@@ -81,15 +137,18 @@ const ProductInfoAndButtons = ({ detail }) => {
 
 ProductInfoAndButtons.propTypes = {
   detail: PropTypes.shape({
+    id: PropTypes.number,
+    productId: PropTypes.number,
     price: PropTypes.number,
     maxParticipants: PropTypes.number,
+    currentParticipants: PropTypes.number,
     createdAt: PropTypes.string,
     updatedAt: PropTypes.string,
     deadline: PropTypes.string,
     title: PropTypes.string,
     category: PropTypes.string,
     place: PropTypes.string,
-  }),
+  }).isRequired,
 };
 
 export default ProductInfoAndButtons;
@@ -156,7 +215,12 @@ const ParticipateButton = styled(ButtonStyle)`
   height: 56px;
   padding: 0px 10px;
   font-size: 15px;
+
+  background: ${({ $closed }) => ($closed ? '#eee' : undefined)};
+  color: ${({ $closed }) => ($closed ? '#aaa' : undefined)};
+  cursor: ${({ $closed }) => ($closed ? 'not-allowed' : 'pointer')};
 `;
+
 const InquiryButton = styled(ButtonStyle)`
   width: 155px;
   height: 56px;

--- a/src/components/RequireAuth.jsx
+++ b/src/components/RequireAuth.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import { Navigate, useLocation } from 'react-router-dom';
+
+function RequireAuth({ children }) {
+  const accessToken = localStorage.getItem('accessToken');
+  const location = useLocation();
+
+  if (!accessToken) {
+    alert('로그인 후 이용하세요.');
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+  return children;
+}
+
+RequireAuth.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default RequireAuth;

--- a/src/layout/Header/Header.jsx
+++ b/src/layout/Header/Header.jsx
@@ -48,7 +48,7 @@ const Header = () => {
             <Divider></Divider>
             <FeatureText onClick={() => navigate('/mypage')}>마이 페이지</FeatureText>
             <Divider></Divider>
-            <FeatureText>모아톡</FeatureText>
+            <FeatureText onClick={() => navigate('/chat')}>모아톡</FeatureText>
           </FeaturePanel>
         </MainHeader>
         <CategoryContainer ref={categoryRef}>

--- a/src/pages/Chat/Chat.jsx
+++ b/src/pages/Chat/Chat.jsx
@@ -1,25 +1,100 @@
-import { useState } from 'react';
+import api from '@api/api';
+import { useEffect, useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { chatRooms, messagesByRoom } from './MockData/MockData';
 import LogoIcon from '@assets/chat/logo-icon.svg?react';
-import { ChatRoomList, QuitButton } from '@components/Chat/ChatRoomList';
-import { MessageList, ChatInput } from '@components/Chat/MessageList';
-
+import ChatRoomList from '@components/Chat/ChatRoomList';
+import MessageList from '@components/Chat/MessageList';
 import { Container } from '@components/shared/UIStyles';
-import { ButtonStyle } from '@components/shared/ButtonStyle';
-import { Avatar } from '@components/Chat/shared/Avatar';
 
 const Chat = () => {
-  const initialActiveRoom = chatRooms.find((r) => r.active) || chatRooms[0];
-  const [activeRoomId, setActiveRoomId] = useState(initialActiveRoom.id);
-  const [inputValue, setInputValue] = useState('');
+  const [chatRooms, setChatRooms] = useState([]);
+  const [activeRoomId, setActiveRoomId] = useState(null);
+  const navigate = useNavigate();
 
-  const activeRoom = chatRooms.find((room) => room.id === activeRoomId);
-  const messages = messagesByRoom[activeRoomId] || [];
+  // 채팅방 목록 불러오기
+  const fetchChatRooms = useCallback(async () => {
+    try {
+      const res = await api.get('/api/auth/users/chats');
+      console.log('채팅방 목록(roomId):', res.data.data && res.data.data.map((r) => r.roomId));
+      if (res.data.status === 'OK') {
+        setChatRooms(res.data.data || []);
+      }
+    } catch (err) {
+      if (err.response?.status === 401) {
+        alert('로그인이 필요합니다. 다시 로그인 해주세요.');
+        navigate('/login');
+      }
+    }
+  }, [activeRoomId]);
 
-  const handleSend = () => {
-    // 메시지 전송 로직 구현 필요
-    setInputValue('');
+  useEffect(() => {
+    fetchChatRooms();
+  }, [fetchChatRooms]);
+
+  useEffect(() => {
+    const roomId = location.state?.roomId ? String(location.state?.roomId) : null;
+    if (roomId && chatRooms.some((r) => r.roomId === roomId)) {
+      setActiveRoomId(roomId);
+    } else if (chatRooms.length > 0 && !activeRoomId) {
+      setActiveRoomId(chatRooms[0].roomId);
+    }
+  }, [location.state, chatRooms]);
+
+  const activeRoom = chatRooms.find((r) => String(r.roomId) === String(activeRoomId));
+
+  // 채팅방 나가기
+  const handleQuit = async (room) => {
+    if (room.isHost) {
+      alert('주최자는 참여중인 공동구매 인원이 있다면 나갈 수 없습니다!');
+      return;
+    }
+    if (window.confirm('채팅방에서 나가고 공동구매 참여를 취소하시겠습니까?')) {
+      try {
+        // 1. 공동구매 참여 취소 (참여 상태 확인 후)
+        const statusRes = await api.get(`/api/group-buyings/${room.product?.productId}/status`);
+        const isJoined = statusRes.data?.data?.isJoined;
+        if (!isJoined) {
+          alert('이미 참여를 취소한한 공동구매입니다.');
+          //채팅방만 나가기
+          await api.delete(`/api/chats/rooms/${room.roomId}/leave`);
+          await fetchChatRooms();
+          const remainRooms = chatRooms.filter((r) => r.roomId !== room.roomId);
+          setActiveRoomId(remainRooms[0]?.roomId || null);
+          return;
+        }
+        // 2. userId를 localStorage에서 꺼내서 사용
+        const userId = localStorage.getItem('userId');
+        const productId = room.product?.productId;
+        console.log('나가기 요청 userId:', userId, 'productId:', productId);
+
+        if (!userId) {
+          alert('로그인 정보가 없습니다. 다시 로그인 해주세요.');
+          return;
+        }
+        // 3. 공동구매 참여 취소
+        await api.delete(`/api/group-buyings/${room.product?.productId}/participants/${userId}`);
+        // 4. 채팅방 나가기
+        await api.delete(`/api/chats/rooms/${room.roomId}/leave`);
+        await fetchChatRooms();
+        const updatedRooms = chatRooms.filter((r) => r.roomId !== room.roomId);
+        setActiveRoomId(updatedRooms[0]?.roomId || null);
+      } catch (e) {
+        const msg = e.response?.data?.message || '';
+        console.error(e.response?.data?.message || e);
+        if (e.response?.status === 403) {
+          alert('주최자는 게시글을 삭제해야 나갈 수 있습니다.');
+        } else if (msg.includes('not joined')) {
+          // 이미 나간 상태에서 또 나가기 시도
+          await api.delete(`/api/chats/rooms/${room.roomId}/leave`);
+          await fetchChatRooms();
+          const remainRooms = chatRooms.filter((r) => r.roomId !== room.roomId);
+          setActiveRoomId(remainRooms[0]?.roomId || null);
+        } else {
+          alert('나가기 실패');
+        }
+      }
+    }
   };
 
   return (
@@ -37,31 +112,11 @@ const Chat = () => {
           />
         </Sidebar>
         <MainPanel>
-          <MainHeader>
-            <MainRow>
-              <MainHeaderLeft>
-                <Avatar src={activeRoom.avatar} alt={activeRoom.title} size="40px" />
-                <MainTitle>{activeRoom.title}</MainTitle>
-              </MainHeaderLeft>
-              <QuitButton />
-            </MainRow>
-            <MainRow>
-              <ProductInfo>
-                <ProductAvatar src={activeRoom.product.imageUrl} alt="상품" />
-                <ProductDetails>
-                  <ProductName>{activeRoom.product.name}</ProductName>
-                  <ProductPrice>{activeRoom.product.price}</ProductPrice>
-                </ProductDetails>
-                <ViewButton>View</ViewButton>
-              </ProductInfo>
-            </MainRow>
-          </MainHeader>
-          <MessageList messages={messages} />
-          <ChatInput
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            onSend={handleSend}
-          />
+          {chatRooms.length === 0 ? (
+            <EmptyMessage>아직 참여한 공동구매가 없습니다!</EmptyMessage>
+          ) : (
+            activeRoom && <MessageList room={activeRoom} onQuit={() => handleQuit(activeRoom)} />
+          )}
         </MainPanel>
       </ChatContainer>
     </ChatWrapper>
@@ -70,7 +125,6 @@ const Chat = () => {
 
 export default Chat;
 
-// 스타일 컴포넌트 정의
 const ChatWrapper = styled(Container)`
   width: 100%;
   background: #fff;
@@ -79,8 +133,7 @@ const ChatWrapper = styled(Container)`
 const ChatContainer = styled(Container)`
   width: 1050px;
   height: 645px;
-  margin: 150px 0;
-
+  margin: 55px 0 135px 0;
   flex-direction: row;
   background: #fff;
 `;
@@ -88,23 +141,21 @@ const ChatContainer = styled(Container)`
 const Sidebar = styled(Container)`
   width: 300px;
   height: 100%;
-
   overflow: hidden;
   background: #fff;
   border: 1px solid #ced4da;
   border-right: none;
   border-radius: 4px 0 0 4px;
-
-  align-items: flex-start;
+  align-items: stretch;
 `;
 
 const SidebarHeader = styled(Container)`
   height: 73px;
   padding: 0 16px;
   border-bottom: 1px solid #e5e7eb;
-
   flex-direction: row;
   gap: 20px;
+  flex-shrink: 0;
 `;
 
 const SidebarTitle = styled.p`
@@ -120,78 +171,11 @@ const MainPanel = styled(Container)`
   border-radius: 0 4px 4px 0;
 `;
 
-const MainHeader = styled(Container)`
+const EmptyMessage = styled(Container)`
   width: 100%;
-  height: 155px;
-  padding: 16px;
-  border-bottom: 1px solid #e5e7eb;
-
-  justify-content: space-between;
-  gap: 12px;
-`;
-
-const MainRow = styled(Container)`
-  width: 100%;
-
-  flex-direction: row;
-  justify-content: space-between;
-`;
-
-const MainHeaderLeft = styled(Container)`
-  flex-direction: row;
-`;
-
-const MainTitle = styled.div`
-  ${({ theme }) => theme.fontStyles.Body6};
-  font-weight: 600;
-  color: #333;
-`;
-
-const ProductInfo = styled(Container)`
-  width: 100%;
-  height: 72px;
-  padding: 12px;
-
-  flex-direction: row;
-  background: #f9fafb;
-  border-radius: 4px;
-`;
-
-const ProductAvatar = styled.img`
-  width: 48px;
-  height: 48px;
-  border-radius: 4px;
-  margin-right: 12px;
-`;
-
-const ProductDetails = styled(Container)`
-  flex: 1;
-  align-items: flex-start;
-  gap: 5px;
-`;
-
-const ProductName = styled.p`
-  ${({ theme }) => theme.fontStyles.Body7};
-  font-weight: 600;
-  color: #555;
-`;
-
-const ProductPrice = styled.p`
-  ${({ theme }) => theme.fontStyles.Body8};
-  font-weight: 500;
-  color: #666;
-`;
-
-const ViewButton = styled(ButtonStyle)`
-  width: 62px;
-  height: 36px;
-  ${({ theme }) => theme.fontStyles.Body7};
-
-  display: flex;
-  align-items: center;
+  height: 100%;
   justify-content: center;
-
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+  ${({ theme }) => theme.fontStyles.Body5};
+  font-weight: 500;
+  color: #b5b5b5;
 `;

--- a/src/pages/ProductDetail/ProductDetail.jsx
+++ b/src/pages/ProductDetail/ProductDetail.jsx
@@ -42,6 +42,7 @@ const ProductDetail = () => {
 
   if (isLoading) return <div>로딩 중...</div>;
   if (hasError || !detail) return <div>게시글을 불러올 수 없습니다.</div>;
+  if (!detail) return <div />;
 
   return (
     <ProductDetailContainer>

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,4 +28,7 @@ export default defineConfig({
   build: {
     outDir: 'build',
   },
+  define: {
+    global: {},
+  },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,6 +796,11 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.39.0.tgz"
   integrity sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==
 
+"@stomp/stompjs@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@stomp/stompjs/-/stompjs-7.1.1.tgz#9a836da33bed5b76c72a8f17f0594de98120f6d6"
+  integrity sha512-chcDs6YkAnKp1FqzwhGvh3i7v0+/ytzqWdKYw6XzINEKAzke/iD00dNgFPWSZEqktHOK+C1gSzXhLkLbARIaZw==
+
 "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
   version "8.0.0"
   resolved "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz"
@@ -1156,6 +1161,13 @@ browserslist@^4.24.0:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
+bufferutil@^4.0.1:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/bufferutil/-/bufferutil-4.0.9.tgz#6e81739ad48a95cad45a279588e13e95e24a800a"
+  integrity sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"
@@ -1352,6 +1364,14 @@ csstype@3.1.3, csstype@^3.0.2:
   resolved "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
+d@1, d@^1.0.1, d@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.2.tgz#2aefd554b81981e7dccf72d6842ae725cb17e5de"
+  integrity sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==
+  dependencies:
+    es5-ext "^0.10.64"
+    type "^2.7.2"
+
 dargs@^8.0.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/dargs/-/dargs-8.1.0.tgz"
@@ -1383,6 +1403,20 @@ data-view-byte-offset@^1.0.1:
     call-bound "^1.0.2"
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
+
+debug@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 debug@^4.1.0, debug@^4.3.1, debug@^4.3.2:
   version "4.4.0"
@@ -1604,6 +1638,33 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
 
+es5-ext@^0.10.35, es5-ext@^0.10.62, es5-ext@^0.10.63, es5-ext@^0.10.64, es5-ext@~0.10.14:
+  version "0.10.64"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
+  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
+  dependencies:
+    es6-iterator "^2.0.3"
+    es6-symbol "^3.1.3"
+    esniff "^2.0.1"
+    next-tick "^1.1.0"
+
+es6-iterator@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
+  integrity sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==
+  dependencies:
+    d "1"
+    es5-ext "^0.10.35"
+    es6-symbol "^3.1.1"
+
+es6-symbol@^3.1.1, es6-symbol@^3.1.3:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.4.tgz#f4e7d28013770b4208ecbf3e0bf14d3bcb557b8c"
+  integrity sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==
+  dependencies:
+    d "^1.0.2"
+    ext "^1.7.0"
+
 esbuild@^0.25.0:
   version "0.25.2"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz"
@@ -1751,6 +1812,16 @@ eslint@^9.21.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
+esniff@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/esniff/-/esniff-2.0.1.tgz#a4d4b43a5c71c7ec51c51098c1d8a29081f9b308"
+  integrity sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.62"
+    event-emitter "^0.3.5"
+    type "^2.7.2"
+
 espree@^10.0.1, espree@^10.3.0:
   version "10.3.0"
   resolved "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz"
@@ -1789,6 +1860,26 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-emitter@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  integrity sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+eventsource@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
+  integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
+
+ext@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ext/-/ext-1.7.0.tgz#0ea4383c0103d60e70be99e9a7f11027a33c4f5f"
+  integrity sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==
+  dependencies:
+    type "^2.7.2"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
@@ -1813,6 +1904,13 @@ fast-uri@^3.0.1:
   version "3.0.6"
   resolved "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz"
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
+
+faye-websocket@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
+  integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
+  dependencies:
+    websocket-driver ">=0.5.1"
 
 file-entry-cache@^8.0.0:
   version "8.0.0"
@@ -2044,6 +2142,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+http-parser-js@>=0.5.1:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.10.tgz#b3277bd6d7ed5588e20ea73bf724fcbe44609075"
+  integrity sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==
+
 husky@^9.1.7:
   version "9.1.7"
   resolved "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz"
@@ -2076,6 +2179,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inherits@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 ini@4.1.1:
   version "4.1.1"
@@ -2269,6 +2377,11 @@ is-typed-array@^1.1.13, is-typed-array@^1.1.14, is-typed-array@^1.1.15:
   integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
   dependencies:
     which-typed-array "^1.1.16"
+
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
 
 is-weakmap@^2.0.2:
   version "2.0.2"
@@ -2521,7 +2634,12 @@ minimist@^1.2.8:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-ms@^2.1.3:
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+  integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
+
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2536,6 +2654,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
 no-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz"
@@ -2548,6 +2671,11 @@ node-addon-api@^7.0.0:
   version "7.1.1"
   resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
+
+node-gyp-build@^4.3.0:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
+  integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
 node-releases@^2.0.19:
   version "2.0.19"
@@ -2781,6 +2909,11 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 react-dom@^19.0.0:
   version "19.1.0"
   resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz"
@@ -2859,6 +2992,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
@@ -2917,6 +3055,11 @@ safe-array-concat@^1.1.3:
     get-intrinsic "^1.2.6"
     has-symbols "^1.1.0"
     isarray "^2.0.5"
+
+safe-buffer@>=5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-push-apply@^1.0.0:
   version "1.0.0"
@@ -3062,6 +3205,17 @@ snake-case@^3.0.4:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+sockjs-client@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/sockjs-client/-/sockjs-client-1.6.1.tgz#350b8eda42d6d52ddc030c39943364c11dcad806"
+  integrity sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==
+  dependencies:
+    debug "^3.2.7"
+    eventsource "^2.0.2"
+    faye-websocket "^0.11.4"
+    inherits "^2.0.4"
+    url-parse "^1.5.10"
+
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
@@ -3071,6 +3225,13 @@ split2@^4.0.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
+stompjs@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/stompjs/-/stompjs-2.3.3.tgz#34178ac7bb8ee294cc5d554ad8b50f7f5459fd8e"
+  integrity sha512-5l/Ogz0DTFW7TrpHF0LAETGqM/so8UxNJvYZjJKqcX31EVprSQgnGkO80tZctPC/lFBDUrSFiTG3xd0R27XAIA==
+  optionalDependencies:
+    websocket latest
 
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
@@ -3236,6 +3397,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type@^2.7.2:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/type/-/type-2.7.3.tgz#436981652129285cc3ba94f392886c2637ea0486"
+  integrity sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==
+
 typed-array-buffer@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz"
@@ -3281,6 +3447,13 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 unbox-primitive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz"
@@ -3316,6 +3489,21 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+url-parse@^1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
+
+utf-8-validate@^5.0.2:
+  version "5.0.10"
+  resolved "https://registry.yarnpkg.com/utf-8-validate/-/utf-8-validate-5.0.10.tgz#d7d10ea39318171ca982718b6b96a8d2442571a2"
+  integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
+  dependencies:
+    node-gyp-build "^4.3.0"
+
 vite-plugin-svgr@^4.3.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/vite-plugin-svgr/-/vite-plugin-svgr-4.3.0.tgz"
@@ -3335,6 +3523,32 @@ vite@^6.2.0:
     rollup "^4.30.1"
   optionalDependencies:
     fsevents "~2.3.3"
+
+websocket-driver@>=0.5.1:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
+  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  dependencies:
+    http-parser-js ">=0.5.1"
+    safe-buffer ">=5.1.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+websocket@latest:
+  version "1.0.35"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.35.tgz#374197207d7d4cc4c36cbf8a1bb886ee52a07885"
+  integrity sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==
+  dependencies:
+    bufferutil "^4.0.1"
+    debug "^2.2.0"
+    es5-ext "^0.10.63"
+    typedarray-to-buffer "^3.1.5"
+    utf-8-validate "^5.0.2"
+    yaeti "^0.0.6"
 
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
@@ -3414,6 +3628,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
+  integrity sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
## 채팅화면 API 연동

### 이슈 번호 📎

- Feature: 채팅화면 api 연동 #50 

### 변경사항 🛠

- 대충 채팅화면 API 연동 : 사용 API - 로그인, 게시글 상세페이지, 공동구매 참여, 공동구매 상태 확인, 공동구매 참여 취소, 채팅방 참여, 사용자의 채팅방 목록 조회, 특정 채팅방 메시지 조회, 채팅 메시지 전송, 채팅방 나가기
- 연동 중에 대충 몇몇 UI 수정, 몇몇 기능 추가
- 로그인쪽 응답 userId랑 userEmail 추가로 받아서 로그인 파일 수정함
- 로그인 안한 상태로 채팅화면 들어가려고하면 진입 못하게 alert 띄우고 로그인화면으로 네비게이션
- 헤더에서 "모아톡" 클릭, 상세화면에서 공구 참여 시 채팅화면으로 네비게이션 → 아무튼 여기저기서 네비게이션

### 특이사항 📌

- 이거 연동한다고 주말동안 밤새고 밥도 못먹어서 이제 손 안댈래요 알아서 해주세요 과제랑 공부 다 밀림 17학점임 양해 좀
